### PR TITLE
Replace mapfile usage with POSIX-compatible array loading

### DIFF
--- a/discover.sh
+++ b/discover.sh
@@ -101,14 +101,29 @@ echo "Extracted $(wc -l <$READABLE | tr -d ' ') symbols"
 
 rm -f $OBFUSCATED $OBFUSCATED_MAPPED
 
-mapfile -t readables < $READABLE
-if [ ${#readables[@]} -gt 0 ]; then
-    mapfile -t hashes < <(python3 obfuscate.py obfuscate "${readables[@]}")
-    for i in "${!readables[@]}"; do
-        echo "${hashes[$i]}: ${readables[$i]}" >> $OBFUSCATED_MAPPED
-        echo "${hashes[$i]}" >> $OBFUSCATED
-    done
-fi
+########################################
+#  REPLACED MAPFILE BLOCK (MAC SAFE)
+########################################
+
+# Load readable keys into array
+readables=()
+while IFS= read -r line; do
+    readables+=("$line")
+done < "$READABLE"
+
+# Call python to get hashes, load into array
+hashes=()
+while IFS= read -r line; do
+    hashes+=("$line")
+done < <(python3 obfuscate.py obfuscate "${readables[@]}")
+
+# Write both output files
+for i in "${!readables[@]}"; do
+    echo "${hashes[$i]}: ${readables[$i]}" >> "$OBFUSCATED_MAPPED"
+    echo "${hashes[$i]}" >> "$OBFUSCATED"
+done
+
+########################################
 
 sort -f $OBFUSCATED_MAPPED -o $OBFUSCATED_MAPPED
 


### PR DESCRIPTION
macOS ships an old Bash (3.2) which doesn’t support mapfile/readarray. This was causing the script to fail on systems that aren’t using Homebrew’s Bash. Swapped the mapfile block for a portable while-read loop so the script now runs correctly on stock macOS bash without requiring any shell upgrades.